### PR TITLE
fix: correção da altura do header, section e footer

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -3,6 +3,7 @@
 * {
   margin: 0;
   padding: 0;
+  box-sizing: border-box;
 }
 
 h1 {
@@ -26,6 +27,7 @@ a {
   align-items: center;
   padding: 20px;
   background-color: #311700;
+  height: 10vh;
 }
 
 #cabecalho a {
@@ -55,12 +57,12 @@ li {
 }
 
 #conteudo {
-  height: 500px;
+  height: 80vh;
   display: flex;
   flex-wrap: wrap;
   justify-content: center;
   align-items: center;
-  flex-direction: column;  
+  flex-direction: column;
   background-color: #311700;
 }
 
@@ -79,6 +81,7 @@ li {
 #rodape {
   padding: 20px;
   background-color: #5b3508;
+  height: 10vh;
 }
 
 #rodape p {


### PR DESCRIPTION
- correção da altura do header, section e footer que estava fazendo com que
aparecesse uma barra branca abaixo na página. Adicionei a unidade de medida
'vh' permitindo que independente do tamanho da tela, o header vai ocupar 10%,
a section 80% e o footer 10%, ocupando todos toda a tela, sem a aparição da
faixa branca ao fundo.

- tbm adicionei a propriedade 'box-sizing: border-box' pra que tudo fique
mais proporcional.

valeus!

ACEITE MINHAS MODIFICAÇÕES!